### PR TITLE
エラーメッセージを出す時に落ちる不具合の修正

### DIFF
--- a/src/application.rs
+++ b/src/application.rs
@@ -403,14 +403,13 @@ impl Application {
             time: 0.0,
         };
         let frame_counter = FrameCounter::new(&self.ui_props)?;
-        self.renderer.wait_all_signals();
-        self.state = State::Rendering(Rendering {
+        self.set_state(State::Rendering(Rendering {
             path: path.to_path_buf(),
             parameters,
             ps,
             frame_counter,
             show_frame_counter: self.show_frame_counter.clone(),
-        });
+        }));
         self.start_time = std::time::Instant::now();
         self.window_receiver
             .main_window
@@ -577,14 +576,19 @@ impl Application {
             .inner_size()
             .to_logical(dpi)
             .cast::<f32>();
-        self.state = State::Error(ErrorMessage::new(
+        self.set_state(State::Error(ErrorMessage::new(
             path.to_path_buf(),
             self.window_receiver.main_window.clone(),
             &e,
             &self.ui_props,
             [size.width, size.height].into(),
-        )?);
+        )?));
         error!("{}", e);
         Ok(())
+    }
+
+    fn set_state(&mut self, new_state: State) {
+        self.renderer.wait_all_signals();
+        self.state = new_state;
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,7 +73,7 @@ fn main() {
             .payload()
             .downcast_ref::<String>()
             .map(|s| s.as_str())
-            .or_else(|| info.payload().downcast_ref::<&str>().map(|s| *s));
+            .or_else(|| info.payload().downcast_ref::<&str>().copied());
         match msg {
             Some(msg) => {
                 let s = match info.location() {

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -234,7 +234,7 @@ impl Renderer {
         cmd_list.reset(&cmd_allocators[0])?;
         if let Some(ps) = ps {
             if let Some(parameters) = parameters {
-                let shader = self.pixel_shader.apply(&ps, &parameters);
+                let shader = self.pixel_shader.apply(ps, parameters);
                 let target = self.render_target.target(index);
                 cmd_list.barrier([target.enter()]);
                 cmd_list.clear(&target, clear_color);

--- a/src/renderer/command_queue.rs
+++ b/src/renderer/command_queue.rs
@@ -47,12 +47,11 @@ impl Signals {
     }
 
     pub fn wait_all(&self) {
-        let event = Event::new().unwrap();
         let mut signals = self.signals.borrow_mut();
         for signal in signals.iter_mut().map(|s| s.take()).flatten() {
             if !signal.is_completed() {
-                signal.set_event(&event).unwrap();
-                event.wait();
+                signal.set_event(&self.event).unwrap();
+                self.event.wait();
             }
         }
     }

--- a/src/renderer/command_queue.rs
+++ b/src/renderer/command_queue.rs
@@ -48,7 +48,7 @@ impl Signals {
 
     pub fn wait_all(&self) {
         let mut signals = self.signals.borrow_mut();
-        for signal in signals.iter_mut().map(|s| s.take()).flatten() {
+        for signal in signals.iter_mut().flat_map(|s| s.take()) {
             if !signal.is_completed() {
                 signal.set_event(&self.event).unwrap();
                 self.event.wait();
@@ -91,7 +91,7 @@ impl CommandQueue {
         cmd_lists: &[Option<ID3D12CommandList>],
     ) -> Result<Signal, Error> {
         unsafe {
-            self.queue.ExecuteCommandLists(&cmd_lists);
+            self.queue.ExecuteCommandLists(cmd_lists);
             self.signal()
         }
     }


### PR DESCRIPTION
レンダリングの終了を待たずにState::Errorに置き換えてしまって、State::Renderingのpsが使用中に破棄されていた。

Fixed #23 