### PR TITLE
ファイル読み込み時にパニックを起こす問題の修正

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,5 @@
 use crate::*;
+use std::path::PathBuf;
 use windows::Win32::Graphics::Direct3D::Dxc::*;
 
 struct Messages {
@@ -50,8 +51,8 @@ pub enum Error {
     Deserialize(#[from] toml::de::Error),
     #[error("{0}")]
     Compile(String),
-    #[error("{}", MESSAGES.read_file)]
-    ReadFile,
+    #[error("{}({})", MESSAGES.read_file, .0.display())]
+    ReadFile(PathBuf),
     #[error("{}", MESSAGES.create_file)]
     CreateFile,
     #[error("{}", MESSAGES.file_too_large)]

--- a/src/hlsl.rs
+++ b/src/hlsl.rs
@@ -246,12 +246,12 @@ impl Compiler {
     ) -> Result<Blob, Error> {
         let path = path.as_ref();
         let data = {
-            let file = File::open(path).map_err(|_| Error::ReadFile)?;
+            let file = File::open(path).map_err(|_| Error::ReadFile(path.into()))?;
             let mut reader = BufReader::new(file);
             let mut data = String::new();
             reader
                 .read_to_string(&mut data)
-                .map_err(|_| Error::ReadFile)?;
+                .map_err(|_| Error::ReadFile(path.into()))?;
             data
         };
         let (args, _tmp) = create_args(entry_point, target, path.to_str(), args);

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,6 +49,8 @@ static ENV_ARGS: Lazy<EnvArgs> = Lazy::new(|| {
 static EXE_DIR_PATH: Lazy<std::path::PathBuf> = Lazy::new(|| {
     std::env::current_exe()
         .unwrap()
+        .canonicalize()
+        .unwrap()
         .parent()
         .unwrap()
         .to_path_buf()

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -97,12 +97,12 @@ impl Settings {
                 .map_err(|_| Error::CreateFile)?;
             info!("create \"settings.toml\"");
         }
-        let file = File::open(path).map_err(|_| Error::ReadFile)?;
+        let file = File::open(path).map_err(|_| Error::ReadFile(path.into()))?;
         let mut reader = BufReader::new(file);
         let mut buffer = String::new();
         reader
             .read_to_string(&mut buffer)
-            .map_err(|_| Error::ReadFile)?;
+            .map_err(|_| Error::ReadFile(path.into()))?;
         Ok(toml::from_str(&buffer)?)
     }
 


### PR DESCRIPTION
ファイル以外のパスやファイル名のみを渡すとパニックを起こしてメッセージボックスが出ていた。

Fix #63