### PR TITLE
settings.tomlのエラーをウィンドウで表示するようにした

### DIFF
--- a/src/application.rs
+++ b/src/application.rs
@@ -536,7 +536,7 @@ impl Application {
                     debug!("WindowEvent::Closed");
                     match window.save(&*WINDOW_SETTING_PATH) {
                         Ok(_) => info!("save window setting"),
-                        Err(e)  => error!("save window setting: {}", e),
+                        Err(e) => error!("save window setting: {}", e),
                     }
                     break;
                 }

--- a/src/application.rs
+++ b/src/application.rs
@@ -306,7 +306,7 @@ impl Application {
             shader_model,
         )?;
         let factory = renderer.mltg_factory();
-        let ui_props = UiProperties::new(&settings, &factory)?;
+        let ui_props = UiProperties::new(settings, &factory)?;
         let show_frame_counter = Rc::new(Cell::new(settings.frame_counter));
         let exe_dir_monitor = DirMonitor::new(&*EXE_DIR_PATH)?;
         let screen_shot = ScreenShot::new();
@@ -564,8 +564,8 @@ impl Application {
                         }
                     }
                     State::Error(e) => {
-                        if e.path() != &*SETTINGS_PATH
-                            && e.path() != &*WINDOW_SETTING_PATH
+                        if e.path() != *SETTINGS_PATH
+                            && e.path() != *WINDOW_SETTING_PATH
                             && e.path() == path
                         {
                             if let Err(e) = self.load_file(&path) {
@@ -674,7 +674,7 @@ impl Application {
                 ];
             }
             State::Error(em)
-                if em.path() == &*SETTINGS_PATH || em.path() == &*WINDOW_SETTING_PATH =>
+                if em.path() == *SETTINGS_PATH || em.path() == *WINDOW_SETTING_PATH =>
             {
                 if let Some(path) = em.hlsl_path().cloned() {
                     if let Err(e) = self.load_file(&path) {

--- a/src/application/error_message.rs
+++ b/src/application/error_message.rs
@@ -43,6 +43,7 @@ pub(super) struct ErrorMessage {
     scroll_bar_state: ScrollBarState,
     dy: f32,
     line_height: f32,
+    hlsl_path: Option<PathBuf>,
 }
 
 impl ErrorMessage {
@@ -51,6 +52,7 @@ impl ErrorMessage {
         e: &Error,
         ui_props: &UiProperties,
         view_size: wita::LogicalSize<f32>,
+        hlsl_path: Option<PathBuf>,
     ) -> anyhow::Result<Self> {
         let text = if &path == &*SETTINGS_PATH || &path == &*WINDOW_SETTING_PATH {
             format!("{}:\n{}", path.display(), e)
@@ -68,6 +70,7 @@ impl ErrorMessage {
             scroll_bar_state: ScrollBarState::None,
             dy: 0.0,
             line_height: ui_props.line_height,
+            hlsl_path,
         };
         let mut index = 0;
         let mut height = 0.0;
@@ -85,6 +88,10 @@ impl ErrorMessage {
 
     pub fn path(&self) -> &Path {
         &self.path
+    }
+
+    pub fn hlsl_path(&self) -> Option<&PathBuf> {
+        self.hlsl_path.as_ref()
     }
 
     pub fn offset(&mut self, view_size: wita::LogicalSize<f32>, d: i32) -> anyhow::Result<()> {

--- a/src/application/error_message.rs
+++ b/src/application/error_message.rs
@@ -54,7 +54,7 @@ impl ErrorMessage {
         view_size: wita::LogicalSize<f32>,
         hlsl_path: Option<PathBuf>,
     ) -> anyhow::Result<Self> {
-        let text = if &path == &*SETTINGS_PATH || &path == &*WINDOW_SETTING_PATH {
+        let text = if path == *SETTINGS_PATH || path == *WINDOW_SETTING_PATH {
             format!("{}:\n{}", path.display(), e)
         } else {
             format!("{}", e)

--- a/src/application/error_message.rs
+++ b/src/application/error_message.rs
@@ -52,7 +52,11 @@ impl ErrorMessage {
         ui_props: &UiProperties,
         view_size: wita::LogicalSize<f32>,
     ) -> anyhow::Result<Self> {
-        let text = format!("{}", e);
+        let text = if &path == &*SETTINGS_PATH || &path == &*WINDOW_SETTING_PATH {
+            format!("{}:\n{}", path.display(), e)
+        } else {
+            format!("{}", e)
+        };
         let text = text.split('\n').map(|t| t.to_string()).collect::<Vec<_>>();
         let layouts = VecDeque::new();
         let mut this = Self {

--- a/src/default_settings.toml
+++ b/src/default_settings.toml
@@ -2,13 +2,6 @@ version = [1, 0]
 frame_counter = true
 auto_play = true
 
-[window]
-x = 0
-y = 0
-width = 1024
-height = 768
-maximized = false
-
 [resolution]
 width = 640 
 height = 480 

--- a/src/default_window.toml
+++ b/src/default_window.toml
@@ -1,0 +1,5 @@
+x = 0
+y = 0
+width = 1024
+height = 768
+maximized = false

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -111,7 +111,7 @@ impl Settings {
     pub fn load(path: impl AsRef<Path>) -> Result<Self, Error> {
         Ok(toml::from_str(&load_file(
             path.as_ref(),
-            &DEFAULT_SETTINGS,
+            DEFAULT_SETTINGS,
         )?)?)
     }
 }
@@ -133,7 +133,7 @@ pub struct Window {
 
 impl Window {
     pub fn load(path: impl AsRef<Path>) -> Result<Self, Error> {
-        Ok(toml::from_str(&load_file(path.as_ref(), &DEFAULT_WINDOW)?)?)
+        Ok(toml::from_str(&load_file(path.as_ref(), DEFAULT_WINDOW)?)?)
     }
 
     pub fn save(&self, path: impl AsRef<Path>) -> Result<(), Error> {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -109,7 +109,10 @@ where
 
 impl Settings {
     pub fn load(path: impl AsRef<Path>) -> Result<Self, Error> {
-        Ok(toml::from_str(&load_file(path.as_ref(), &DEFAULT_SETTINGS)?)?)
+        Ok(toml::from_str(&load_file(
+            path.as_ref(),
+            &DEFAULT_SETTINGS,
+        )?)?)
     }
 
     pub fn save(&self, path: impl AsRef<Path>) -> Result<(), Error> {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -114,10 +114,6 @@ impl Settings {
             &DEFAULT_SETTINGS,
         )?)?)
     }
-
-    pub fn save(&self, path: impl AsRef<Path>) -> Result<(), Error> {
-        save_file(path.as_ref(), self)
-    }
 }
 
 impl Default for Settings {
@@ -158,5 +154,10 @@ mod tests {
     #[test]
     fn default_settings() {
         Settings::default();
+    }
+
+    #[test]
+    fn default_window_setting() {
+        Window::default();
     }
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -4,6 +4,7 @@ use std::io::{BufReader, BufWriter, Read, Write};
 use std::path::Path;
 
 const DEFAULT_SETTINGS: &str = include_str!("default_settings.toml");
+const DEFAULT_WINDOW: &str = include_str!("default_window.toml");
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug, serde::Serialize, serde::Deserialize)]
 #[serde(into = "[u32; 2]")]
@@ -22,15 +23,6 @@ impl std::fmt::Display for Version {
     fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(fmt, "{}.{}", self.major, self.minor)
     }
-}
-
-#[derive(Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
-pub struct Window {
-    pub x: i32,
-    pub y: i32,
-    pub width: u32,
-    pub height: u32,
-    pub maximized: bool,
 }
 
 #[derive(Clone, Copy, Debug, serde::Serialize, serde::Deserialize)]
@@ -80,45 +72,79 @@ pub struct Settings {
     pub version: Version,
     pub frame_counter: bool,
     pub auto_play: bool,
-    pub window: Window,
     pub resolution: Resolution,
     pub shader: Shader,
     pub appearance: Appearance,
 }
 
-impl Settings {
-    pub fn load(path: impl AsRef<Path>) -> Result<Self, Error> {
-        let path = path.as_ref();
-        if !path.is_file() {
-            let file = File::create(path).map_err(|_| Error::CreateFile)?;
-            let mut writer = BufWriter::new(file);
-            writer
-                .write_all(DEFAULT_SETTINGS.as_bytes())
-                .map_err(|_| Error::CreateFile)?;
-            info!("create \"settings.toml\"");
-        }
-        let file = File::open(path).map_err(|_| Error::ReadFile(path.into()))?;
-        let mut reader = BufReader::new(file);
-        let mut buffer = String::new();
-        reader
-            .read_to_string(&mut buffer)
-            .map_err(|_| Error::ReadFile(path.into()))?;
-        Ok(toml::from_str(&buffer)?)
-    }
-
-    pub fn save(&self, path: impl AsRef<Path>) -> Result<(), Error> {
+fn load_file(path: &Path, default: &str) -> Result<String, Error> {
+    if !path.is_file() {
         let file = File::create(path).map_err(|_| Error::CreateFile)?;
         let mut writer = BufWriter::new(file);
         writer
-            .write_all(toml::to_string(self)?.as_bytes())
+            .write_all(default.as_bytes())
             .map_err(|_| Error::CreateFile)?;
-        Ok(())
+        info!("create \"{}\"", path.display());
+    }
+    let file = File::open(path).map_err(|_| Error::ReadFile(path.into()))?;
+    let mut reader = BufReader::new(file);
+    let mut buffer = String::new();
+    reader
+        .read_to_string(&mut buffer)
+        .map_err(|_| Error::ReadFile(path.into()))?;
+    Ok(buffer)
+}
+
+fn save_file<T>(path: &Path, this: &T) -> Result<(), Error>
+where
+    T: serde::Serialize,
+{
+    let file = File::create(path).map_err(|_| Error::CreateFile)?;
+    let mut writer = BufWriter::new(file);
+    writer
+        .write_all(toml::to_string(this)?.as_bytes())
+        .map_err(|_| Error::CreateFile)?;
+    Ok(())
+}
+
+impl Settings {
+    pub fn load(path: impl AsRef<Path>) -> Result<Self, Error> {
+        Ok(toml::from_str(&load_file(path.as_ref(), &DEFAULT_SETTINGS)?)?)
+    }
+
+    pub fn save(&self, path: impl AsRef<Path>) -> Result<(), Error> {
+        save_file(path.as_ref(), self)
     }
 }
 
 impl Default for Settings {
     fn default() -> Self {
         toml::from_str(DEFAULT_SETTINGS).unwrap()
+    }
+}
+
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub struct Window {
+    pub x: i32,
+    pub y: i32,
+    pub width: u32,
+    pub height: u32,
+    pub maximized: bool,
+}
+
+impl Window {
+    pub fn load(path: impl AsRef<Path>) -> Result<Self, Error> {
+        Ok(toml::from_str(&load_file(path.as_ref(), &DEFAULT_WINDOW)?)?)
+    }
+
+    pub fn save(&self, path: impl AsRef<Path>) -> Result<(), Error> {
+        save_file(path.as_ref(), self)
+    }
+}
+
+impl Default for Window {
+    fn default() -> Self {
+        toml::from_str(DEFAULT_WINDOW).unwrap()
     }
 }
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -130,13 +130,9 @@ impl WindowHandler {
             ))
             .inner_size(wita::PhysicalSize::new(
                 window_setting.width,
-                settings.as_ref().map_or(
-                    window_setting.height,
-                    |settings| {
-                        window_setting.width * settings.resolution.height
-                            / settings.resolution.width
-                    },
-                ),
+                settings.as_ref().map_or(window_setting.height, |settings| {
+                    window_setting.width * settings.resolution.height / settings.resolution.width
+                }),
             ))
             .accept_drag_files(true)
             .build()


### PR DESCRIPTION
* settings.tomlの`[window]`をwindows.tomlに分けた。
* settings.tomlでエラーが出ている時はHLSLファイルを読み込めないようにした。

Close #67 